### PR TITLE
[CP-83] Remove leftovers of old usb security implementation

### DIFF
--- a/harness.py
+++ b/harness.py
@@ -49,12 +49,6 @@ class Harness:
     def get_application_name(self):
         return self.connection.get_application_name()
 
-    def unlock_usb(self):
-        self.connection.usb_unlock()
-
-    def lock_usb(self):
-        self.connection.usb_lock()
-
     def is_phone_locked(self):
         return self.connection.is_phone_locked()
 

--- a/interface/CDCSerial.py
+++ b/interface/CDCSerial.py
@@ -130,22 +130,6 @@ class CDCSerial:
         ret = self.write(self.__wrap_message(body))
         return ret["body"]["isLocked"]
 
-    def usb_lock(self):
-        body = {
-            "usbSecurityStatus": "locked"
-        }
-
-        ret = self.write(self.__wrap_message(body))
-        return ret["status"]
-
-    def usb_unlock(self):
-        body = {
-            "usbSecurityStatus": "unlocked"
-        }
-
-        ret = self.write(self.__wrap_message(body))
-        return ret["status"]
-
     @staticmethod
     def find_Pures() -> str:
         '''


### PR DESCRIPTION
USB security is being changed, and old implementation (and tests for it) is no longer needed.