### PR TITLE
[CP-388] Add 409 Conflict status code

### DIFF
--- a/interface/defs.py
+++ b/interface/defs.py
@@ -60,6 +60,7 @@ status = {
     "Forbidden": 403,
     "NotFound": 404,
     "NotAcceptable": 406,
+    "Conflict": 409,
     "InternalServerError": 500,
     "NotImplemented": 501,
 }


### PR DESCRIPTION
Code 409 is needed for responses informing about detected duplicate.