### PR TITLE
[CP-1421] Add delay after ttyACMx device detection

### DIFF
--- a/rt_harness_discovery.py
+++ b/rt_harness_discovery.py
@@ -15,7 +15,11 @@ def get_harness_automatic(timeout, retry_time_s=1) -> Harness:
         retry_time_s - time between open retries
     '''
     harness = None
-    timeout_started = time.time()
+
+    # There is a period of time between the moment the device is detected and when it is ready
+    # to accept commands. All data sent during this window will be lost, so wait for the time
+    # defined here before sending anything.
+    detection_to_readiness_time = 5
 
     log.debug(f'await for port {timeout}s')
     with Timeout.limit(seconds=timeout):
@@ -26,7 +30,8 @@ def get_harness_automatic(timeout, retry_time_s=1) -> Harness:
                 if e.get_error_code() == Error.PORT_NOT_FOUND:
                     time.sleep(retry_time_s)
             if harness is not None:
-                log.debug("found port")
+                log.debug(f'found port, waiting {detection_to_readiness_time}s for device to be ready')
+                time.sleep(detection_to_readiness_time)
     return harness
 
 
@@ -39,7 +44,6 @@ def get_harness_by_port_name(port: str, timeout, retry_time_s=1) -> Harness:
         retry_time_s - time between open retries
     '''
     assert '/dev' in port or simulator_port in port
-    timeout_started = time.time()
 
     if simulator_port in port:
         file = None


### PR DESCRIPTION
Add delay between detection of the ttyACMx
device and the start of sending data to it,
so that PureOS has the time to fully
initialize.