### PR TITLE
[MOS-903] Remove reboot to USB MSC mode

### DIFF
--- a/api/update.py
+++ b/api/update.py
@@ -21,13 +21,3 @@ class PhoneReboot(GenericTransaction):
     def onRun(self, harness):
         harness.reboot_requested = True
 
-class RebootToUsbMscMode(GenericTransaction):
-    """
-    Reboot device to USB MSC mode
-    """
-
-    def __init__(self):
-        self.request = Request(Endpoint.UPDATE, Method.PUT, {"rebootMode": "usbMscMode"})
-
-    def setResponse(self, response: Response):
-        self.response = GenericResponse(response)


### PR DESCRIPTION
Remove API entry for rebooting to MSC mode
as it will be removed from MuditaOS as
unused and potentially unsafe.