### PR TITLE
[BH-1842] Fix dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,9 @@ attrs==20.3.0
 iniconfig==1.1.1
 packaging==20.4
 pluggy==0.13.1
-py==1.9.0
 pyparsing==2.4.7
 pyserial==3.5
-pytest==6.2.4
+pytest>=7.2.0
 pytest-order==1.0.0
 six==1.15.0
 toml==0.10.2


### PR DESCRIPTION
GitHub's dependabot suggests we might be using outdated and vulnerable python libraries in particular the py library which was necessary for older pytest versions.